### PR TITLE
Update Calen Walshe profile details

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -35,7 +35,7 @@ header:
     show_search: true
     show_theme_chooser: true
     logo:
-      text: 'Your Name'
+      text: 'Calen Walshe'
 
 # Site footer
 footer:

--- a/content/_index.md
+++ b/content/_index.md
@@ -34,11 +34,11 @@ sections:
       title: '📚 My Research'
       subtitle: ''
       text: |-
-        Use this area to speak to your mission. I'm a quantitative researcher at Meta focused on product experimentation and data-driven decision making. I share insights on causal inference, experimentation platforms, and analytics leadership.
+        Calen Walshe’s work sits at the intersection of visual neuroscience, attention, and eye-movement control. He has developed computational accounts of how gaze and fixation durations are governed during naturalistic scene viewing and category learning—work that grew from his PhD on eye-movement mechanisms and later modeling of dual-process control of fixation time.
 
-        I apply a range of qualitative and quantitative methods to comprehensively investigate the role of data and technology in shaping product ecosystems.
+        He has also run psychophysics and modeling studies revealing how humans covertly allocate attentional sensitivity across space—showing unexpected losses in visual sensitivity during broad covert searches—and how the visual system detects partially occluded targets in natural backgrounds.
 
-        Please reach out to collaborate 😃
+        Much of this research was conducted as a postdoctoral fellow in Bill Geisler’s lab at UT Austin, focusing on visual and cognitive mechanisms that link learning, attention, and gaze.
     design:
       columns: '1'
   - block: collection

--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -36,22 +36,18 @@ profiles:
   - icon: at-symbol
     url: 'mailto:calen.walshe@meta.com'
     label: E-mail Me
-  - icon: brands/x
-    url: https://twitter.com/CalenWalshe
   - icon: brands/github
-    url: https://github.com/calenwalshe
+    url: https://calenwalshe.github.com
   - icon: brands/linkedin
-    url: https://www.linkedin.com/in/calenwalshe/
+    url: https://www.linkedin.com/in/calen-walshe-ab708364/
   - icon: academicons/google-scholar
-    url: https://scholar.google.com/citations?user=calenwalshe
-  - icon: academicons/orcid
-    url: https://orcid.org/0000-0002-1825-0097
+    url: https://scholar.google.com/citations?user=uZYVTRcAAAAJ&hl=en
 
 interests:
-  - Large Language Models
-  - Computer Vision
-  - Reinforcement Learning
-  - AI Ethics
+  - Visual Neuroscience
+  - Cognitive Science
+  - Attention and Eye-Movement Control
+  - Computational Models of Gaze
 
 education:
   - area: B.A. (Hons) in Cognitive Science
@@ -154,4 +150,8 @@ awards:
       Recognized for contributions to scaling laws in deep learning.
 ---
 
-Calen Walshe is a Quantitative Researcher at Meta who builds data-driven experimentation programs to inform product decisions at scale. His work blends econometrics, causal inference, and machine learning to uncover actionable insights that improve the Meta family of apps. Calen is passionate about mentoring analytics teams, speaking at industry meetups, and exploring new ways to turn complex datasets into clear narratives.
+Calen Walshe’s work sits at the intersection of visual neuroscience, attention, and eye-movement control. He has developed computational accounts of how gaze and fixation durations are governed during naturalistic scene viewing and category learning—work that grew from his PhD on eye-movement mechanisms and later modeling of dual-process control of fixation time.
+
+He has also run psychophysics and modeling studies revealing how humans covertly allocate attentional sensitivity across space—showing unexpected losses in visual sensitivity during broad covert searches—and how the visual system detects partially occluded targets in natural backgrounds.
+
+Much of this research was conducted as a postdoctoral fellow in Bill Geisler’s lab at UT Austin, focusing on visual and cognitive mechanisms that link learning, attention, and gaze.


### PR DESCRIPTION
## Summary
- update navbar branding to show Calen Walshe's name
- refresh homepage research summary with neuroscience-focused description
- revise author profile links and interests to emphasize neuroscience and include requested profiles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9f096264883249eabafef1d41f8a6