### PR TITLE
Remove pronoun display from admin author profile

### DIFF
--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -9,9 +9,6 @@ name_pronunciation: ''
 first_name: Calen
 last_name: Walshe
 
-# Pronouns (optional)
-pronouns: he/him
-
 # Status emoji
 status:
   icon: 🚀


### PR DESCRIPTION
## Summary
- remove the pronouns metadata from the admin author profile so the site no longer shows "he/him" beneath the name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9f151c52883248abf860125b8c196