### PR TITLE
fix: remove featured publication placeholder image

### DIFF
--- a/content/publication/efficient-allocation-attentional-sensitivity/index.md
+++ b/content/publication/efficient-allocation-attentional-sensitivity/index.md
@@ -21,7 +21,7 @@ summary: >-
   Demonstrates how efficient allocation of attentional sensitivity during visual search produces substantial foveal sensitivity
   reductions in naturalistic large displays.
 tags: []
-featured: false
+featured: true
 links:
   - type: custom
     label: Publisher


### PR DESCRIPTION
## Summary
- mark the "Efficient Allocation of Attentional Sensitivity Gain in Visual Cortex" article as featured so it surfaces on the homepage grid
- remove the temporary placeholder banner metadata and asset to comply with binary restrictions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9f986f70483249e626038b27fe8e2