### PR TITLE
Update site title to Calen Walshe

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -4,7 +4,7 @@
 # This file is formatted using YAML syntax - learn more at https://learnxinyminutes.com/docs/yaml/
 
 # Website name
-title: Hugo Academic CV Theme
+title: Calen Walshe
 # Website URL
 baseURL: 'https://example.com/'
 


### PR DESCRIPTION
## Summary
- update the Hugo configuration title to display "Calen Walshe"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca52ad12248324ab4f54eca7025651