### PR TITLE
Remove Talks navigation link

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -10,12 +10,9 @@ main:
   - name: Papers
     url: /#papers
     weight: 11
-  - name: Talks
-    url: /#talks
-    weight: 12
   - name: News
     url: /#news
-    weight: 13
+    weight: 12
   - name: Experience
     url: experience/
     weight: 20


### PR DESCRIPTION
## Summary
- remove the Talks item from the main navigation menu
- shift the News menu weight to fill the gap left by Talks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca5f3ef2548324b972164c06868f9a