### PR TITLE
Remove news navigation and section

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -10,9 +10,6 @@ main:
   - name: Papers
     url: /#papers
     weight: 11
-  - name: News
-    url: /#news
-    weight: 12
   - name: Experience
     url: experience/
     weight: 20

--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -1,4 +1,11 @@
 ---
 title: Blog
+_build:
+  render: never
+  list: never
+cascade:
+  _build:
+    render: never
+    list: never
 view: article-grid
 ---


### PR DESCRIPTION
## Summary
- remove the News item from the main navigation menu
- disable the blog/news section by preventing the `post` section from rendering

## Testing
- not run (hugo CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca648feba08324949a84ee7fbfa6be