### PR TITLE
Link Experience menu to homepage section

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -11,5 +11,5 @@ main:
     url: /#papers
     weight: 11
   - name: Experience
-    url: experience/
+    url: /#experience
     weight: 20

--- a/content/_index.md
+++ b/content/_index.md
@@ -39,6 +39,7 @@ sections:
     design:
       view: citation
   - block: resume-experience
+    id: experience
     content:
       title: Experience
       username: admin


### PR DESCRIPTION
## Summary
- add a stable `experience` id to the resume-experience block on the landing page
- point the Experience navigation item to the new homepage anchor so it scrolls to the section

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb03f3ace88324b07dc5329e414b00