### PR TITLE
Update experience section with new roles

### DIFF
--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -61,39 +61,60 @@ education:
 
 
 work:
-  - position: Staff Quantitative Researcher, Ad Technology
+  - position: Staff Quantitative Researcher
     company_name: Meta
     company_url: 'https://www.meta.com/'
     company_logo: ''
-    date_start: 2021-01-01
+    date_start: 2021-11-01
     date_end: ''
     summary: |-
-      - Steered ad-quality measurement using Hive analytics and large-N surveys; influenced >$1B revenue and roadmaps across ranking and creative systems.
-      - Built ad-performance classifiers at Meta scale; improved AUC +3–5 pts and calibration error −20–30%, informing ranking and budget allocation decisions.
-      - Designed causal measurement combining experiments and observational logs; delivered trustworthy lift readouts for launches across key ad surfaces.
-      - Linked survey signals to on-platform behavior with Bayesian hierarchical models; reduced bias 15–25% and improved targeting validity across cohorts.
-      - Authored reusable Hive pipelines and SQL UDFs; cut insight turnaround 30–40% and standardized metrics across Ads teams.
-      - Led 50+ experiments annually; applied variance-reduction techniques to shrink required samples 20–30% while maintaining power and guardrails.
-      - Partnered with PM/Eng as Staff-level bridge; raised decision velocity 25–35% via playbooks, dashboards, and preregistered analysis templates.
-      - Prototyped ad-tech POCs (creative quality, budget pacing); projected ROI +8–12%, enabling investment decisions and phased rollouts.
-      - Instituted experiment quality gating—power analyses, holdout checks, pre-mortems—reducing false launches 20–30% and boosting trust in causal readouts.
-      - Defined UX quality metrics (fatigue, diversity, trust) balancing revenue and experience; enabled ranking changes with consistent 2–4% engagement lift.
+      I analyze billions of user interactions to distill complex data into clear, actionable product strategies. My expertise lies in transforming large-scale data insights directly into impactful product decisions.
   - position: Data Scientist
-    company_name: C. Light Technologies
+    company_name: C. Light Technologies, Inc.
     company_url: 'https://clighttechnologies.com/'
     company_logo: ''
-    date_start: 2021-01-01
-    date_end: 2021-12-31
+    date_start: 2021-03-01
+    date_end: 2021-11-01
     summary: |-
-      - Built classifiers on retinal images and eye-movements to screen neurological disease; achieved AUC 0.85–0.92 and accelerated analyses 40–50%.
-  - position: Quantitative Research Intern
-    company_name: OpenAI
-    company_url: 'https://openai.com/'
+      I developed the core software algorithms powering an advanced retinal scanning system, enabling accurate detection and filtering of low-quality medical images. My work directly enhanced the device’s diagnostic precision and reliability.
+  - position: Research Scientist
+    company_name: The University of Texas at Austin
+    company_url: 'https://www.utexas.edu/'
     company_logo: ''
-    date_start: 2019-06-01
-    date_end: 2019-12-31
-    summary: |
-      Developed Bayesian experimentation tooling to support early reinforcement learning research initiatives.
+    date_start: 2015-08-01
+    date_end: 2021-03-01
+    summary: |-
+      Built and validated large-scale computational models of cortical circuits to probe memory, attention, and decision-making.
+
+      Secured competitive grant funding and co-authored numerous peer-reviewed publications and conference presentations that advanced the field of cognitive neuroscience.
+  - position: Data Scientist
+    company_name: The Edinburgh Journal Ltd
+    company_url: ''
+    company_logo: ''
+    date_start: 2013-01-01
+    date_end: 2015-01-01
+    summary: |-
+      I predicted tomorrow’s news trends to help readers connect deeply with their city. By building analytics that anticipated demand, my work directly boosted the Journal’s readership.
+  - position: Research Scientist
+    company_name: Mediative
+    company_url: ''
+    company_logo: ''
+    date_start: 2010-01-01
+    date_end: 2011-01-01
+    summary: |-
+      Ran EEG- and eye-tracking studies to map attention and emotion to ad performance and in-store behavior.
+
+      Converted neural signals into predictive models of click-through and purchase intent, shaping campaign and site-design decisions for major retail and tech clients.
+
+      Published industry whitepapers and presented findings at neuromarketing conferences, elevating Mediative’s market profile.
+  - position: Data and Research Science Intern
+    company_name: Natural Sciences and Engineering Research Council of Canada (NSERC)
+    company_url: 'https://nserc-crsng.gc.ca/'
+    company_logo: ''
+    date_start: 2008-01-01
+    date_end: 2008-12-31
+    summary: |-
+      Supported research initiatives in Vancouver, BC, combining data analysis with experimental design to advance scientific discovery.
 
 # Skills
 # Add your own SVG icons to `assets/media/icons/`


### PR DESCRIPTION
## Summary
- refresh the experience section for the admin profile with updated roles and descriptions
- add narrative summaries for each role spanning Meta, C. Light Technologies, UT Austin, The Edinburgh Journal, Mediative, and NSERC

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb306697c08324bd89b77abfc14751