### PR TITLE
Add CV navigation tab and expose resume bundle

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -13,3 +13,6 @@ main:
   - name: Experience
     url: /#experience
     weight: 20
+  - name: CV
+    url: /calen_cv/
+    weight: 21

--- a/config/_default/module.yaml
+++ b/config/_default/module.yaml
@@ -23,3 +23,5 @@ mounts:
     target: layouts
   - source: assets
     target: assets
+  - source: docs/calen_cv
+    target: static/calen_cv

--- a/docs/calen_cv/index.html
+++ b/docs/calen_cv/index.html
@@ -1,16 +1,13 @@
-
-  <!DOCTYPE html>
-  <html lang="en">
-    <head>
-      <meta charset="UTF-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>Create CV for Calen Walshe</title>
-      <script type="module" crossorigin src="/assets/index-CZVrmBA4.js"></script>
-      <link rel="stylesheet" crossorigin href="/assets/index-BvSIevmP.css">
-    </head>
-
-    <body>
-      <div id="root"></div>
-    </body>
-  </html>
-  
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Create CV for Calen Walshe</title>
+    <script type="module" crossorigin src="./assets/index-CZVrmBA4.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-BvSIevmP.css">
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a CV navigation link that points to the resume bundle
- mount the generated resume site under /calen_cv and fix its asset paths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddd8f39b60832490c42eee247652d6