### PR TITLE
Refine publication listings on homepage

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -30,9 +30,17 @@ sections:
         size: medium # Options: small (150px), medium (200px, default), large (320px), xl (400px), xxl (500px)
         shape: circle # Options: circle (default), square, rounded
   - block: collection
-    id: papers
+    id: selected-publications
     content:
-      title: Papers
+      title: Selected Publications
+      filters:
+        featured: true
+    design:
+      view: citation
+  - block: collection
+    id: publications-full
+    content:
+      title: Full Publications List
       filters:
         folders:
           - publication

--- a/content/publication/_index.md
+++ b/content/publication/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Publications
+title: Full Publications List
 cms_exclude: true
 
 # View.

--- a/content/publication/atari-head-atari-human-eye-tracking-and-demonstration-dataset/index.md
+++ b/content/publication/atari-head-atari-human-eye-tracking-and-demonstration-dataset/index.md
@@ -16,7 +16,7 @@ publication_types: ["paper-conference"]
 publication: "*Proceedings of the Thirty-Fourth AAAI Conference on Artificial Intelligence (AAAI-20)*"
 publication_short: "Proceedings of the Thirty-Fourth AAAI Conference on Artificial Intelligence (AAAI-20)"
 summary: ""
-featured: false
+featured: true
 tags: []
 links: []
 projects: []

--- a/content/publication/learning-induced-changes-in-attentional-allocation-during-categorization-a-sizable-catalog-of-attention-change-as-measured-by-eye-movements/index.md
+++ b/content/publication/learning-induced-changes-in-attentional-allocation-during-categorization-a-sizable-catalog-of-attention-change-as-measured-by-eye-movements/index.md
@@ -13,7 +13,7 @@ publication_types: ["article-journal"]
 publication: "*PLOS ONE* 9(1), e83302"
 publication_short: "PLOS ONE"
 summary: ""
-featured: false
+featured: true
 tags: []
 links: []
 projects: []

--- a/content/publication/mechanisms-of-saccadic-decision-making-while-encoding-naturalistic-scenes/index.md
+++ b/content/publication/mechanisms-of-saccadic-decision-making-while-encoding-naturalistic-scenes/index.md
@@ -9,7 +9,7 @@ publication_types: ["article-journal"]
 publication: "*Journal of Vision* 15(5), 21-21"
 publication_short: "Journal of Vision"
 summary: ""
-featured: false
+featured: true
 tags: []
 links: []
 projects: []

--- a/content/publication/retinal-task-detection-and-image-perception-using-end-to-end-deep-neural-network-dnn-based-algorithms/index.md
+++ b/content/publication/retinal-task-detection-and-image-perception-using-end-to-end-deep-neural-network-dnn-based-algorithms/index.md
@@ -12,7 +12,7 @@ publication_types: ["article-journal"]
 publication: "*Investigative Ophthalmology & Visual Science* 63(7), 735–F0463-735–F0463"
 publication_short: "Investigative Ophthalmology & Visual Science"
 summary: ""
-featured: false
+featured: true
 tags: []
 links: []
 projects: []


### PR DESCRIPTION
## Summary
- rename the homepage publications block to "Selected Publications" and filter it to featured entries
- add a second collection block for the full publication list and retitle the publications index page accordingly
- flag key publications as featured so they surface in the curated list

## Testing
- not run (content changes only)

------
https://chatgpt.com/codex/tasks/task_e_68de2205345083249c1f02e45c621b7b