### PR TITLE
Adjust publication section spacing

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -39,6 +39,7 @@ sections:
         featured_only: true
     design:
       view: citation
+      spacing: '0rem'
   - block: markdown
     id: pubs-toggle
     content:
@@ -91,6 +92,8 @@ sections:
         });
         </script>
         {{< /rawhtml >}}
+    design:
+      spacing: '0rem'
   - block: collection
     id: papers
     content:
@@ -100,6 +103,7 @@ sections:
           - publication
     design:
       view: citation
+      spacing: '0rem'
   - block: resume-experience
     id: experience
     content:


### PR DESCRIPTION
## Summary
- override the landing page spacing for the selected publications block
- remove inherited section padding from the publications toggle markdown block
- align the all publications collection with the tighter spacing adjustments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ded7680bb08324939d23e33e6a7e3d