### PR TITLE
Remove Download CV button from homepage biography

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -14,10 +14,6 @@ sections:
       # Choose a user profile to display (a folder name within `content/authors/`)
       username: admin
       text: ''
-      # Show a call-to-action button under your biography? (optional)
-      button:
-        text: Download CV
-        url: uploads/resume.pdf
       headings:
         about: ''
         education: ''


### PR DESCRIPTION
## Summary
- remove the biography call-to-action button that linked to the CV to hide the Download CV entry on the homepage

## Testing
- npm run dev *(fails: hugo command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ded866e2b883249dcac3ace478d853