### PR TITLE
Add gallery below selected publications

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -126,6 +126,54 @@ sections:
           - 0
           - 0rem
           - 0
+  - block: markdown
+    id: selected-gallery
+    content:
+      text: |
+        {{< rawhtml >}}
+        <style>
+          .selected-gallery {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.25rem;
+            justify-content: center;
+            margin: 1.5rem 0 0;
+          }
+
+          .selected-gallery a {
+            flex: 1 1 200px;
+            max-width: 240px;
+            display: block;
+            text-decoration: none;
+          }
+
+          .selected-gallery img {
+            width: 100%;
+            height: auto;
+            border-radius: 12px;
+            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+            display: block;
+          }
+        </style>
+        <div class="selected-gallery">
+          <a href="/media/efficient-allocation-figure.jpg" target="_blank" rel="noopener">
+            <img src="/media/efficient-allocation-figure.jpg" alt="Visualization of efficient allocation of attentional gain" loading="lazy">
+          </a>
+          <a href="/media/efficient-allocation-figure.jpg" target="_blank" rel="noopener">
+            <img src="/media/efficient-allocation-figure.jpg" alt="Diagram illustrating resource allocation efficiency" loading="lazy">
+          </a>
+          <a href="/media/efficient-allocation-figure.jpg" target="_blank" rel="noopener">
+            <img src="/media/efficient-allocation-figure.jpg" alt="Graphic overview of attentional resource distribution" loading="lazy">
+          </a>
+        </div>
+        {{< /rawhtml >}}
+    design:
+      spacing:
+        padding:
+          - 0rem
+          - 0
+          - 0rem
+          - 0
   - block: collection
     id: papers
     content:


### PR DESCRIPTION
## Summary
- insert a new markdown block after the selected publications toggle to showcase a gallery
- wrap the gallery markup in a rawhtml shortcode with inline flexbox styling for responsive spacing
- render three linked image tiles that open the high-resolution figure in a new tab with accessible alt text

## Testing
- npm run build *(fails: hugo executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68deedc4e3a88324bdb8458803f61737