### PR TITLE
Reorder homepage gallery and adjust layout styling

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -42,6 +42,55 @@ sections:
           - 0rem
           - 0
   - block: markdown
+    id: selected-gallery
+    content:
+      text: |
+        {{< rawhtml >}}
+        <style>
+          .selected-gallery {
+            display: flex;
+            flex-wrap: nowrap;
+            overflow-x: auto;
+            gap: 1.25rem;
+            justify-content: center;
+            margin: 1.5rem 0 0;
+          }
+
+          .selected-gallery a {
+            flex: 0 0 240px;
+            max-width: 240px;
+            display: block;
+            text-decoration: none;
+          }
+
+          .selected-gallery img {
+            width: 100%;
+            height: auto;
+            border-radius: 12px;
+            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+            display: block;
+          }
+        </style>
+        <div class="selected-gallery">
+          <a href="/media/efficient-allocation-figure.jpg" target="_blank" rel="noopener">
+            <img src="/media/efficient-allocation-figure.jpg" alt="Visualization of efficient allocation of attentional gain" loading="lazy">
+          </a>
+          <a href="/media/efficient-allocation-figure.jpg" target="_blank" rel="noopener">
+            <img src="/media/efficient-allocation-figure.jpg" alt="Diagram illustrating resource allocation efficiency" loading="lazy">
+          </a>
+          <a href="/media/efficient-allocation-figure.jpg" target="_blank" rel="noopener">
+            <img src="/media/efficient-allocation-figure.jpg" alt="Graphic overview of attentional resource distribution" loading="lazy">
+          </a>
+        </div>
+        {{< /rawhtml >}}
+    design:
+      spacing:
+        padding:
+          - 0rem
+          - 0
+          - 0rem
+          - 0
+  - block: markdown
     id: pubs-toggle
     content:
       text: |
@@ -118,54 +167,6 @@ sections:
           }
         });
         </script>
-        {{< /rawhtml >}}
-    design:
-      spacing:
-        padding:
-          - 0rem
-          - 0
-          - 0rem
-          - 0
-  - block: markdown
-    id: selected-gallery
-    content:
-      text: |
-        {{< rawhtml >}}
-        <style>
-          .selected-gallery {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 1.25rem;
-            justify-content: center;
-            margin: 1.5rem 0 0;
-          }
-
-          .selected-gallery a {
-            flex: 1 1 200px;
-            max-width: 240px;
-            display: block;
-            text-decoration: none;
-          }
-
-          .selected-gallery img {
-            width: 100%;
-            height: auto;
-            border-radius: 12px;
-            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
-            display: block;
-          }
-        </style>
-        <div class="selected-gallery">
-          <a href="/media/efficient-allocation-figure.jpg" target="_blank" rel="noopener">
-            <img src="/media/efficient-allocation-figure.jpg" alt="Visualization of efficient allocation of attentional gain" loading="lazy">
-          </a>
-          <a href="/media/efficient-allocation-figure.jpg" target="_blank" rel="noopener">
-            <img src="/media/efficient-allocation-figure.jpg" alt="Diagram illustrating resource allocation efficiency" loading="lazy">
-          </a>
-          <a href="/media/efficient-allocation-figure.jpg" target="_blank" rel="noopener">
-            <img src="/media/efficient-allocation-figure.jpg" alt="Graphic overview of attentional resource distribution" loading="lazy">
-          </a>
-        </div>
         {{< /rawhtml >}}
     design:
       spacing:


### PR DESCRIPTION
## Summary
- move the selected gallery section before the publications toggle so the thumbnails appear above the button
- update the gallery flex styles to keep thumbnails on a single horizontal row with optional horizontal scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68defd08c3bc8324967798869ff4ee64