### PR TITLE
Remove redundant Meta label from author profile

### DIFF
--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -23,9 +23,7 @@ highlight_name: true
 role: Quantitative Research Leader | AI/ML for Ads Ranking & UX at Meta
 
 # Organizations/Affiliations to display in Biography blox
-organizations:
-  - name: Meta
-    url: https://www.meta.com/
+organizations: []
 
 # Social network links
 # Need to use another icon? Simply download the SVG icon to your `assets/media/icons/` folder.


### PR DESCRIPTION
## Summary
- remove the author organization entry so the extra "Meta" label no longer renders in the hero profile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df593676788324a17e69691f62b6f1