### PR TITLE
Remove interests section from admin profile

### DIFF
--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -38,12 +38,6 @@ profiles:
   - icon: academicons/google-scholar
     url: https://scholar.google.com/citations?user=uZYVTRcAAAAJ&hl=en
 
-interests:
-  - Visual Neuroscience
-  - Cognitive Science
-  - Attention and Eye-Movement Control
-  - Computational Models of Gaze
-
 education:
   - area: B.A. (Hons) in Cognitive Science
     institution: Simon Fraser University


### PR DESCRIPTION
## Summary
- remove the interests block from the admin author profile so it no longer renders on the site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df776d9b4083249da9a2aee7f39b20