### PR TITLE
Remove email link from CV header

### DIFF
--- a/calen_cv/src/components/CVHeader.tsx
+++ b/calen_cv/src/components/CVHeader.tsx
@@ -1,4 +1,4 @@
-import { Mail, Globe, Github, Linkedin, MapPin } from 'lucide-react'
+import { Globe, Github, Linkedin, MapPin } from 'lucide-react'
 import { Card } from './ui/card'
 
 export function CVHeader() {
@@ -11,13 +11,6 @@ export function CVHeader() {
         </h2>
         
         <div className="flex flex-wrap justify-center gap-6 pt-4">
-          <div className="flex items-center gap-2">
-            <Mail className="h-4 w-4" />
-            <a href="mailto:calen.walshe@gmail.com" className="hover:text-primary">
-              calen.walshe@gmail.com
-            </a>
-          </div>
-          
           <div className="flex items-center gap-2">
             <Globe className="h-4 w-4" />
             <a href="https://www.calenwalshe.com" className="hover:text-primary" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary
- remove the email contact entry from the CV header
- clean up the unused mail icon import now that the email link is gone

## Testing
- not run (build currently fails due to pre-existing syntax errors in CVSummary.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68df7ee786088324aa596b323928a4d4