### PR TITLE
Adjust CV summary text

### DIFF
--- a/calen_cv/src/components/CVSummary.tsx
+++ b/calen_cv/src/components/CVSummary.tsx
@@ -7,7 +7,14 @@ export function CVSummary() {
         <CardTitle>Summary</CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="leading-relaxed">forthcoming</p>
+        <p className="leading-relaxed">
+          Calen Walshe leads quantitative research and applied ML at Meta. He
+          architects and ships backend systems for ranking, relevance, and
+          content quality, improving user experience across surfaces. He pairs
+          causal inference and A/B testing with MLOps to take models from
+          training to real-time serving with clear SLOs. His background in
+          visual attention guides how he measures and optimizes experience.
+        </p>
       </CardContent>
     </Card>
   )

--- a/calen_cv/src/components/CVSummary.tsx
+++ b/calen_cv/src/components/CVSummary.tsx
@@ -7,13 +7,7 @@ export function CVSummary() {
         <CardTitle>Summary</CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="leading-relaxed">
-          Calen Walshe leads quantitative research and applied ML at Meta. He architects and ships backend systems for ranking,
-          relevance, and content quality, improving user experience across surfaces.{'
-          '}He pairs causal inference and A/B testing with MLOps to take models from training to real-time serving with clear
-          SLOs.{'
-          '}His background in visual attention guides how he measures and optimizes experience.
-        </p>
+        <p className="leading-relaxed">forthcoming</p>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary
- restore the original summary text for the Get Started post
- update the calen_cv summary component to display the placeholder text "forthcoming"

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173`

------
https://chatgpt.com/codex/tasks/task_e_68e09e3eeb708324866d87255a241dd3