### PR TITLE
Fix navigation anchor for Bio tab

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -5,7 +5,7 @@
 
 main:
   - name: Bio
-    url: /
+    url: /#bio
     weight: 10
   - name: Papers
     url: /#papers

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,6 +10,7 @@ design:
 
 sections:
   - block: resume-biography-3
+    id: bio
     content:
       # Choose a user profile to display (a folder name within `content/authors/`)
       username: admin


### PR DESCRIPTION
## Summary
- assign an anchor ID to the biography section on the landing page
- update the Bio menu item to point to the biography section anchor

## Testing
- `npm run build` *(fails: `hugo` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f09d35022c83248e50593bfc1f779b